### PR TITLE
Fix typo in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,6 @@
 use inc::Module::Install;
 
-all_from 'lib/Business/Bitpay.pm';
+all_from 'lib/Business/BitPay.pm';
 
 requires 'Carp';
 requires 'HTTP::Request';


### PR DESCRIPTION
Changing line 3 in Makefile.PL from:

all_from 'lib/Business/Bitpay.pm';

to:

all_from 'lib/Business/BitPay.pm';

since the file it's looking for is BitPay.pm and not Bitpay.pm
